### PR TITLE
Mark parameter optional

### DIFF
--- a/kraken_sdk_rest/src/api/get_closed_orders.rs
+++ b/kraken_sdk_rest/src/api/get_closed_orders.rs
@@ -104,7 +104,7 @@ impl GetClosedOrdersRequest {
 
 #[derive(Debug, Deserialize)]
 pub struct ClosedOrderInfo {
-    pub userref: i32,
+    pub userref: Option<i32>,
     pub status: String,
     pub descr: OrderDescription,
     pub oflags: String,

--- a/kraken_sdk_rest/src/api/get_trades_history.rs
+++ b/kraken_sdk_rest/src/api/get_trades_history.rs
@@ -103,7 +103,7 @@ impl GetTradesHistoryRequest {
 #[derive(Debug, Deserialize)]
 pub struct TradeInfo {
     pub ordertxid: String,
-    pub postxid: String,
+    pub postxid: Option<String>,
     pub pair: String,
     pub time: f64,
     #[serde(rename(deserialize = "type"))]


### PR DESCRIPTION
For me the api returns null for some items for `userref` and `postxid`. The rest api documentation is not 100% clear about if they are optional. At least in reality they are it seems.