### PR TITLE
DepositStatus::fee field is not present while the deposit is settling

### DIFF
--- a/kraken_sdk_rest/src/api/get_deposit_status.rs
+++ b/kraken_sdk_rest/src/api/get_deposit_status.rs
@@ -54,8 +54,8 @@ pub struct DepositStatus {
     pub info: String,
     /// Amount deposited
     pub amount: String,
-    /// Fee paid
-    pub fee: String,
+    /// Fee paid (not present when status == "Settled")
+    pub fee: Option<String>,
     /// Unix timestamp when request was made
     pub time: u64,
     /// Status of deposit


### PR DESCRIPTION
This is a minor change in the public API, not sure if this would be a problem or not. I observed that while a deposit is pending, the `fee` field is not returned by the Kraken API, which causes the response deserialization to fail