### PR TITLE
Add support for TradeVolume private endpoint

### DIFF
--- a/kraken_sdk_rest/src/api.rs
+++ b/kraken_sdk_rest/src/api.rs
@@ -43,6 +43,9 @@ pub use get_account_balance::*;
 pub mod get_trade_balance;
 pub use get_trade_balance::*;
 
+pub mod get_trade_volume;
+pub use get_trade_volume::*;
+
 pub mod get_open_orders;
 pub use get_open_orders::*;
 

--- a/kraken_sdk_rest/src/api/get_trade_volume.rs
+++ b/kraken_sdk_rest/src/api/get_trade_volume.rs
@@ -1,0 +1,89 @@
+use std::collections::HashMap;
+
+use crate::{Client, Result};
+
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+/// - <https://docs.kraken.com/rest/#tag/User-Data/operation/getTradeVolume>
+/// - <https://api.kraken.com/0/private/TradeVolume>
+#[must_use = "Does nothing until you send or execute it"]
+pub struct GetTradeVolumeRequest {
+    client: Client,
+    pair: Option<String>,
+    fee_info: Option<bool>
+}
+
+impl GetTradeVolumeRequest {
+    /// Whether or not to include the fee information in the output
+    pub fn fee_info(self, fee_info: bool) -> Self {
+        Self {
+            fee_info: Some(fee_info),
+            ..self
+        }
+    }
+
+    /// Restrict results to a given trading pair
+    pub fn pair(self, pair: String) -> Self {
+        Self {
+            pair: Some(pair),
+            ..self
+        }
+    }
+
+    pub async fn execute<T: DeserializeOwned>(self) -> Result<T> {
+        let mut query: Vec<String> = Vec::new();
+
+        if let Some(pair) = self.pair {
+            query.push(format!("pair={}", pair));
+        }
+
+        if let Some(true) = self.fee_info {
+            query.push(String::from("fee-info=true"));
+        }
+
+        let query = if query.is_empty() {
+            None
+        } else {
+            Some(query.join("&"))
+        };
+
+        self.client.send_private("/0/private/TradeVolume", query).await
+    }
+
+    pub async fn send(self) -> Result<GetTradeVolumeResponse> {
+        self.execute().await
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct FeeTierInfo {
+    fee: String,
+    #[serde(rename = "minfee")]
+    min_fee: String,
+    #[serde(rename = "maxfee")]
+    max_fee: String,
+    #[serde(rename = "nextfee")]
+    next_fee: Option<String>,
+    #[serde(rename = "tiervolume")]
+    tier_volume: Option<String>,
+    #[serde(rename = "nextvolume")]
+    next_volume: Option<String>
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GetTradeVolumeResponse {
+    pub currency: String,
+    pub volume: String,
+    pub fees: HashMap<String, FeeTierInfo>,
+    pub fees_maker: HashMap<String, FeeTierInfo>
+}
+
+impl Client {
+     pub fn get_trade_volume(&self) -> GetTradeVolumeRequest {
+        GetTradeVolumeRequest {
+            client: self.clone(),
+            pair: None,
+            fee_info: None
+        }
+    }
+}


### PR DESCRIPTION
This is an authenticated endpoint, taking one or more pairs comma separated, eg. "ADAUSD" or "ADAUSD,KAVAUSD" in addition to the optional fee-info. The response tells the level of volume done in the last 30 days revolving in addition to current fee and next fee ( if any ) and next volume level for discount ( if any ).